### PR TITLE
Fixing up docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Install vagrant on your system, and a virtualisation backend, such as Virtual Bo
 For example, on macOS:
 
 ```
-$ brew cask install vagrant
-$ brew cask install virtualbox
+$ brew install --cask vagrant
+$ brew install --cask virtualbox
 ```
 
 Install a vagrant provider plugin to match the backend you chose, and install the `vagrant-reload` plugin:
 
 ```
+$ vagrant plugin update
 $ vagrant plugin install virtualbox
 $ vagrant plugin install vagrant-reload
 ```
@@ -54,31 +55,33 @@ Install VirtualBox Guest Additions:
 
 ```
 $ vagrant plugin install vagrant-vbguest
-$ vagrant vbguest
-$ vagrant reload default
 ```
 
-Clone `docker-worker` and `docker-worker-deploy` as _sibling_ directories on your system, e.g.
+Clone `taskcluster`, and then clone `docker-worker-deploy` inside the `workers`
+directory so that `docker-worker-deploy` and `docker-worker` are _sibling_
+directories on your system, e.g.
 
 ```
-$ mkdir -p ~/git
-$ cd ~/git
-$ git clone git@github.com:taskcluster/docker-worker.git
+$ git clone git@github.com:taskcluster/taskcluster.git
+$ cd taskcluster/workers
 $ git clone git@github.com:taskcluster/docker-worker-deploy.git
 ```
 
 Bring up the vagrant machine:
 
 ```
-$ cd ~/git/docker-worker
+$ cd docker-worker
 $ vagrant up
+$ vagrant vbguest
+$ vagrant reload default
 ```
 
 SSH into the machine, initialise `/worker` directory, and build the docker images locally:
 
 ```
 $ vagrant ssh
-$ cd /worker
+$ cd /docker-worker-deploy
+$ ./vagrant.sh
 $ ./build.sh
 $ curl -o- -L https://yarnpkg.com/install.sh | bash
 $ exit
@@ -89,9 +92,10 @@ $ yarn install
 Export credentials for running integration tests:
 
 ```
+$ export TASKCLUSTER_ROOT_URL='......'
 $ export TASKCLUSTER_CLIENT_ID='......'
 $ export TASKCLUSTER_ACCESS_TOKEN='......'
-$ export TASKCLUSTER_ROOT_URL='......'
+$ export TASKCLUSTER_CERTIFICATE='......'   # not needed if using "permanent" credentials
 ```
 
 Run tests:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ Building EC2 AMIs for docker-worker
 ===================================
 
 You will need taskcluster credentials with suitable scopes (TODO: find out
-which scopes, or ideally a single role, and document it/them here).  You can
-use the
+which scopes, or ideally a single role, and document it/them here) configured
+in `TASKCLUSTER_*` environment variables.  You can use the
 [taskcluster-shell](https://github.com/taskcluster/taskcluster/clients/client-shell)
-tool to get them:
+tool to set them:
 
 ```sh
 $ eval $(taskcluster signin)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Building EC2 AMIs for docker-worker
 ===================================
 
-First of all, you'll need taskcluster credentials with suitable scopes (TODO:
-find out which scopes, or ideally a single role, and document it/them here).
-You can use the
+You will need taskcluster credentials with suitable scopes (TODO: find out
+which scopes, or ideally a single role, and document it/them here).  You can
+use the
 [taskcluster-shell](https://github.com/taskcluster/taskcluster/clients/client-shell)
 tool to get them:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ cd /docker-worker-deploy
 ```
 
 Maybe this has already run (see the `Vagrantfile` inside the
-`workers/docker-worker` directory of the taskcluster monorepo, but if you had
+`workers/docker-worker` directory of the taskcluster monorepo) but if you had
 any failures, you might need to run it again:
 
 ```

--- a/README.md
+++ b/README.md
@@ -81,12 +81,32 @@ $ vagrant vbguest
 $ vagrant reload default
 ```
 
-SSH into the machine, initialise the `/docker-worker-deploy` directory, and build the docker images locally:
+SSH into the machine, initialise the `/docker-worker-deploy` directory, do some more vagrant setup(?)
 
 ```
 $ vagrant ssh
 $ cd /docker-worker-deploy
+```
+
+Maybe this has already run (see the `Vagrantfile` inside the
+`workers/docker-worker` directory of the taskcluster monorepo, but if you had
+any failures, you might need to run it again:
+
+```
 $ ./vagrant.sh
+```
+
+At some point I was asked if I would like to keep my existing `/etc/default/docker` or replace it
+with the version from apt package `docker-ce`. This may be because it took me several iterations to get things working, so this might not happen if things work first time. I chose to keep the version I had (option `O`)
+since from the diff, the package version looks like just comments, but the version on the file system contained the line:
+
+```
+DOCKER_OPTS="--storage-driver overlay2"
+```
+
+At this point you can hopefully build the docker image inside your vagrant VM:
+
+```
 $ ./build.sh
 $ curl -o- -L https://yarnpkg.com/install.sh | bash
 $ exit

--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 Building EC2 AMIs for docker-worker
 ===================================
 
-First of all, you need proper taskcluster credentials. You can use the
+First of all, you'll need taskcluster credentials with suitable scopes (TODO:
+find out which scopes, or ideally a single role, and document it/them here).
+You can use the
 [taskcluster-shell](https://github.com/taskcluster/taskcluster/clients/client-shell)
-tool to get it:
+tool to get them:
 
 ```sh
-# eval $(taskcluster signin)
+$ eval $(taskcluster signin)
 ```
 
-You also need the
-[Taskcluster team passwordstore repo](https://github.com/taskcluster/passwordstore-garbage)
-proper configured. Talk to :dustin to know how to get access to it.
-The deploy scripts require node version >= 12.11.0.
-With all these done, type:
+You also need the [Taskcluster team passwordstore
+repo](https://github.com/taskcluster/passwordstore-garbage) properly configured
+and installed on your system (TODO: presumably also the pass unix utility,
+rather than just a clone of the repo - update docs accordingly). The deploy
+scripts require node version >= 12.11.0.
+
+Execute the following command:
 
 ```sh
-# ./deploy.sh <docker-worker source code path> <build target>
+$ ./deploy.sh <docker-worker source code path> <build target>
 ```
 
 To build docker-worker AMIs. The build target is either `app` or `base`. The base image
@@ -24,15 +28,17 @@ is used to accelarate the process the more common app image. You can also tag a 
 release with:
 
 ```sh
-# ./release.sh
+$ ./release.sh
 ```
 
-To be able to do a Github release, you need a proper key stored in the environment
-variable `DOCKER_WORKER_GITHUB_TOKEN`.
+To be able to make a GitHub release, you'll need to set the environment
+variable `DOCKER_WORKER_GITHUB_TOKEN` with a suitable GitHub access token.
 
-The generate AMI IDs must be update in the
-[ci-configuration](https://hg.mozilla.org/ci/ci-configuration/)
-and [community-tc-config](https://github.com/mozilla/community-tc-config) repositories.
+In order for the docker-worker workers of the firefox-ci-tc and community-tc
+taskcluster deployments to use the newly generated AMIs, the repositories
+[ci-configuration](https://hg.mozilla.org/ci/ci-configuration/) and
+[community-tc-config](https://github.com/mozilla/community-tc-config) will need
+to be updated with the names of the newly generated AMIs.
 
 
 Building under Vagrant

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ vagrant plugin install virtualbox
 $ vagrant plugin install vagrant-reload
 ```
 
-Install VirtualBox Guest Additions:
+Install VirtualBox Guest Additions plugin:
 
 ```
 $ vagrant plugin install vagrant-vbguest
@@ -72,11 +72,16 @@ Bring up the vagrant machine:
 ```
 $ cd docker-worker
 $ vagrant up
+```
+
+Install the VirtualBox Guest Additions on the VM and restart it:
+
+```
 $ vagrant vbguest
 $ vagrant reload default
 ```
 
-SSH into the machine, initialise `/worker` directory, and build the docker images locally:
+SSH into the machine, initialise the `/docker-worker-deploy` directory, and build the docker images locally:
 
 ```
 $ vagrant ssh

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@ Building EC2 AMIs for docker-worker
 First of all, you need proper taskcluster credentials. You can use the
 [taskcluster-shell](https://github.com/taskcluster/taskcluster/clients/client-shell)
 tool to get it:
+
 ```sh
 # eval $(taskcluster signin)
 ```
+
 You also need the
 [Taskcluster team passwordstore repo](https://github.com/taskcluster/passwordstore-garbage)
 proper configured. Talk to :dustin to know how to get access to it.
 The deploy scripts require node version >= 12.11.0.
 With all these done, type:
+
 ```sh
 # ./deploy.sh <docker-worker source code path> <build target>
 ```
+
 To build docker-worker AMIs. The build target is either `app` or `base`. The base image
 is used to accelarate the process the more common app image. You can also tag a github
 release with:
@@ -34,7 +38,8 @@ and [community-tc-config](https://github.com/mozilla/community-tc-config) reposi
 Building under Vagrant
 ======================
 
-Install vagrant on your system, and a virtualisation backend, such as Virtual Box.
+Install vagrant on your system, and a virtualisation backend, such as Virtual
+Box.
 
 For example, on macOS:
 
@@ -43,7 +48,8 @@ $ brew install --cask vagrant
 $ brew install --cask virtualbox
 ```
 
-Install a vagrant provider plugin to match the backend you chose, and install the `vagrant-reload` plugin:
+Install a vagrant provider plugin to match the backend you chose, and install
+the `vagrant-reload` plugin:
 
 ```
 $ vagrant plugin update
@@ -81,7 +87,8 @@ $ vagrant vbguest
 $ vagrant reload default
 ```
 
-SSH into the machine, initialise the `/docker-worker-deploy` directory, do some more vagrant setup(?)
+SSH into the machine, initialise the `/docker-worker-deploy` directory, do some
+more vagrant setup(?)
 
 ```
 $ vagrant ssh
@@ -96,21 +103,39 @@ any failures, you might need to run it again:
 $ ./vagrant.sh
 ```
 
-At some point I was asked if I would like to keep my existing `/etc/default/docker` or replace it
-with the version from apt package `docker-ce`. This may be because it took me several iterations to get things working, so this might not happen if things work first time. I chose to keep the version I had (option `O`)
-since from the diff, the package version looks like just comments, but the version on the file system contained the line:
+At some point I was asked if I would like to keep my existing
+`/etc/default/docker` or replace it with the version from apt package
+`docker-ce`. This may be because it took me several iterations to get things
+working, so this might not happen if things work first time. I chose to keep
+the version I had (option `O`) since from the diff, the package version looks
+like just comments, but the version on the file system contained the line:
 
 ```
 DOCKER_OPTS="--storage-driver overlay2"
 ```
 
-At this point you can hopefully build the docker image inside your vagrant VM:
+The `build.sh` script isn't available inside the VM since it is in the
+`docker-worker` directory and not the `docker-worker-deploy` directory. A
+mistake? Surely you aren't meant to build the docker images directly on your
+host?
 
 ```
 $ ./build.sh
+```
+
+The next instruction said to install yarn as follows; I've no idea why this
+isn't part of the existing scripts.  Perhaps because it is only needed if you
+want to test, so isn't done by default? Presumably this should be done inside
+the VM, rather than on the host. If this isn't done already, maybe we can just
+add it to the existing scripts?
+
+```
 $ curl -o- -L https://yarnpkg.com/install.sh | bash
-$ exit
-$ vagrant ssh
+```
+
+Install required packages:
+
+```
 $ yarn install
 ```
 

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -30,7 +30,7 @@ sudo apt-get install -y software-properties-common
 sudo apt-add-repository -y ppa:taskcluster/ppa
 
 # Add docker gpg key and update sources
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 sudo sh -c 'echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu trusty stable" \
   > /etc/apt/sources.list.d/docker.list'
 


### PR DESCRIPTION
I've no idea if this is going to work at the end, and we'll be able to build docker worker machine images, but since we didn't archive this repo (yet) it can't harm to apply fixes if we spot mistakes.

At the end of the process we can decide if we archive this repo or not, once we know if it provides a reliable way to build the docker-worker machine images or not.